### PR TITLE
fix(ci): Re-fetch all tags after pushing the new version tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,15 +16,15 @@ jobs:
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v4
-        with:
-          go-version: 1.19.x
-      - uses: actions/checkout@v2
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.19.x
       - uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser


### PR DESCRIPTION
Apparently that action uses Github API to create the tag, not git. So we have to fetch it, so goreleaser can use it